### PR TITLE
PHPインストール時にエラーが出るようになっていたので gcc-c++ と libtoolを追加

### DIFF
--- a/roles/php/base/tasks/dependence-packages.yml
+++ b/roles/php/base/tasks/dependence-packages.yml
@@ -3,6 +3,7 @@
   with_items:
     - httpd
     - libmcrypt
+    - libtool
     - libtool-ltdl
     - zlib-devel
     - autoconf
@@ -11,3 +12,4 @@
     - libevent-devel
     - libmemcached
     - libmemcached-devel
+    - gcc-c++


### PR DESCRIPTION
標題の通りです。