### PR TITLE
modify グローバルインストールするnpmパッケージバージョンを現時点の最新状態に更新

### DIFF
--- a/hosts/local/group_vars/all.yml
+++ b/hosts/local/group_vars/all.yml
@@ -1,9 +1,9 @@
 app_user: vagrant
-node_version: v8.9.0
+node_version: v9.8.0
 nodebrew_install_dir: /home/{{ app_user }}/
-npm_version: 5.4.2
-yarn_version: 1.3.2
-serverless_version: 1.24.1
+npm_version: 5.7.1
+yarn_version: 1.5.1
+serverless_version: 1.26.1
 vue_cli_version: 2.9.1
 
 # php.ini


### PR DESCRIPTION
表題の通り。

vue-cliは現在問題が出ているようなのでバージョンアップは行っていない。