### PR TITLE
resolve #26 MySQLのスロークエリログを有効に設定

### DIFF
--- a/roles/mysql/server/tasks/main.yml
+++ b/roles/mysql/server/tasks/main.yml
@@ -10,5 +10,8 @@
 - name: Replace my.cnf
   template: src=my.cnf.j2 dest=/etc/my.cnf owner=root group=root mode=0644
 
+- name: Create SlowQueryLogFile
+  file: path=/var/log/mysql-slow-query.log state=touch owner=mysql group=mysql mode=0644
+
 - name: Add mysqld to StartUps on boot And Be Running
   service: enabled=yes name=mysqld state=started

--- a/roles/mysql/server/templates/my.cnf.j2
+++ b/roles/mysql/server/templates/my.cnf.j2
@@ -35,6 +35,9 @@ innodb_large_prefix=1
 innodb_file_format=Barracuda
 innodb_default_row_format=DYNAMIC
 default_password_lifetime = 0
+slow_query_log = 1
+long_query_time = 0.1
+slow_query_log_file = /var/log/mysql-slow-query.log
 
 [mysql]
 auto-rehash

--- a/roles/mysql/server/templates/my.cnf.j2
+++ b/roles/mysql/server/templates/my.cnf.j2
@@ -28,10 +28,9 @@ pid-file=/var/run/mysqld/mysqld.pid
 
 character-set-server=utf8mb4
 skip-character-set-client-handshake
-default-storage-engine=innodb
 collation-server=utf8mb4_bin
-innodb_file_per_table=1
 default-storage-engine=InnoDB
+innodb_file_per_table=1
 innodb_large_prefix=1
 innodb_file_format=Barracuda
 innodb_default_row_format=DYNAMIC


### PR DESCRIPTION
https://github.com/keitakn/ansible-playbooks/issues/26

以下のSQLで設定が有効になっている事を確認

```
mysql> SHOW VARIABLES LIKE 'slow%';
+---------------------+-------------------------------+
| Variable_name       | Value                         |
+---------------------+-------------------------------+
| slow_launch_time    | 2                             |
| slow_query_log      | ON                            |
| slow_query_log_file | /var/log/mysql-slow-query.log |
+---------------------+-------------------------------+
3 rows in set (0.00 sec)

mysql> SHOW VARIABLES LIKE 'long_query%';
+-----------------+----------+
| Variable_name   | Value    |
+-----------------+----------+
| long_query_time | 0.100000 |
+-----------------+----------+
1 row in set (0.00 sec)
```